### PR TITLE
Add support for multipart transfers

### DIFF
--- a/benchio.yml
+++ b/benchio.yml
@@ -2,6 +2,7 @@ accessKey: MZZRYNUQKEJZUTKLLHAD
 secretKey: hRwZ5GA7VUhh=vLdBLUqZuRqcryqyVHhuCopR5a4
 endpoint: http://localhost:8000
 bucket: testbucket
+multipartSize: 0
 objectSize: 1024
 objectNamePrefix: testobject
 numClients: 10

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,6 +38,7 @@ var runCmd = &cobra.Command{
 			SecretKey:        viper.GetString("secretKey"),
 			Endpoint:         viper.GetString("endpoint"),
 			Bucket:           viper.GetString("bucket"),
+			MultipartSize:    viper.GetInt64("multipartSize"),
 			ObjectSize:       viper.GetInt64("objectSize"),
 			ObjectNamePrefix: viper.GetString("objectNamePrefix"),
 			Clients:          viper.GetSizeInBytes("numClients"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ secretKey: hRwZ5GA7VUhh=vLdBLUqZuRqcryqyVHhuCopR5a4
 endpoint: http://localhost:8000
 bucket: testbucket
 objectSize: 1024
+multipartSize: 0
 objectNamePrefix: testobject
 numClients: 10
 numSamples: 100
@@ -58,6 +59,7 @@ read: true
 | `endpoint`                          | These are endpoint targets for the workloads. Multiple can be passed as a comma separated list.                  |
 | `bucket`                            | The target bucket to be used. Must already be created on the specified endpoint                                  |
 | `objectSize`                        | Size for each object to be used in the workload (Currently measured in bytes)                                    |
+| `multipartSize`                     | Use a multipart transfer, with parts of the given size (in bytes). Use 0 (the default) to disable                |
 | `objectNamePrefix`                  | Prefix to be used in the object naming                                                                           |
 | `numClients`                        | Number of clients, also referred to as 'workers'                                                                 |
 | `numSamples`                        | Number of objects to server to the endpoint                                                                      |


### PR DESCRIPTION
I had to do some S3 testing using large object sizes and ran into issues trying to do them as single requests once I got above 5GB or so. I've adapted your tool (which has been really helpful) to use the S3 Manager to do a multipart upload, and wondered if it would be useful for others?

It's configured by a new option, but turned off by default. Each request only uses a single client - it might be interesting to expand that, but it wasn't necessary for what I was doing. It's the first Go code I've written, so not totally sure I've done everything in the best way.