### PR TITLE
Transfer objects larger than memory limit

### DIFF
--- a/benchio.yml
+++ b/benchio.yml
@@ -3,6 +3,7 @@ secretKey: hRwZ5GA7VUhh=vLdBLUqZuRqcryqyVHhuCopR5a4
 endpoint: http://localhost:8000
 bucket: testbucket
 objectSize: 1024
+objectSplit: 1
 objectNamePrefix: testobject
 numClients: 10
 numSamples: 100

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,6 +39,7 @@ var runCmd = &cobra.Command{
 			Endpoint:         viper.GetString("endpoint"),
 			Bucket:           viper.GetString("bucket"),
 			ObjectSize:       viper.GetInt64("objectSize"),
+			ObjectSplit:      viper.GetSizeInBytes("objectSplit"),
 			ObjectNamePrefix: viper.GetString("objectNamePrefix"),
 			Clients:          viper.GetSizeInBytes("numClients"),
 			ObjectCount:      viper.GetSizeInBytes("numSamples"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ secretKey: hRwZ5GA7VUhh=vLdBLUqZuRqcryqyVHhuCopR5a4
 endpoint: http://localhost:8000
 bucket: testbucket
 objectSize: 1024
+objectSplit: 1
 objectNamePrefix: testobject
 numClients: 10
 numSamples: 100
@@ -58,6 +59,8 @@ read: true
 | `endpoint`                          | These are endpoint targets for the workloads. Multiple can be passed as a comma separated list.                  |
 | `bucket`                            | The target bucket to be used. Must already be created on the specified endpoint                                  |
 | `objectSize`                        | Size for each object to be used in the workload (Currently measured in bytes)                                    |
+| `objectSplit`                       | Split the object in memory into multiple repeated parts, used for transferring very large objects                |
+|                                     | objectSize must divide evenly by objectSplit with no remainder                                                   |
 | `objectNamePrefix`                  | Prefix to be used in the object naming                                                                           |
 | `numClients`                        | Number of clients, also referred to as 'workers'                                                                 |
 | `numSamples`                        | Number of objects to server to the endpoint                                                                      |


### PR DESCRIPTION
This is somewhat related to #15 but it's separate enough that I though it was worth doing in a separate PR. The two will conflict though, so if one is accepted the other will need to be rebased.

The object you test with is all read into memory at once, which means there's a limit on how big an object you can use (and large objects get quite slow). I've adapted this to generate a smaller amount of random data but then read from it repeatedly, which should allow objects of unlimited size.